### PR TITLE
feat: implement dead zone for controller

### DIFF
--- a/main_app.c
+++ b/main_app.c
@@ -36,7 +36,7 @@ static void update_motor_driver_from_control_input( struct bt_hid_state* state )
 	
 	int left_output = forward_speed;
 	int right_output = forward_speed;
-	if( forward_speed > 0 )
+	if( forward_speed > 20 )
 	{
 		if( swerve_right_rate > 0 )
 		{
@@ -49,7 +49,7 @@ static void update_motor_driver_from_control_input( struct bt_hid_state* state )
 			left_output = clamp(left_output, 0, 128);
 		}
 	}
-	else if( forward_speed < 0 )
+	else if( forward_speed < -20 )
 	{
 		if( swerve_right_rate > 0 )
 		{
@@ -64,14 +64,19 @@ static void update_motor_driver_from_control_input( struct bt_hid_state* state )
 	}
 	else
 	{
-		if( swerve_right_rate != 0 )
+		if( swerve_right_rate >= 20 || swerve_right_rate <= -20 )
 		{
 			// rotate in place
 			// This handles both rotate left and right as left will be negative and right positive
 			left_output = swerve_right_rate;
 			right_output = -1*swerve_right_rate;
-		}
+		} 
+		else 
+		{
 		// otherwise no rotation
+			left_output = 0;
+			right_output = 0;
+		}
 	}
 
 	left_output = clamp(left_output, -127, 128);


### PR DESCRIPTION
This change adds a dead zone on either side of neutral for each analog stick. In testing, we found that the default neutral position for the left analog stick was not truly at 128, and not having a dead zone did not provide enough tolerance to let turning in place work normally.

Did the same thing for left and right, because a dead zone is just a helpful practice in general.